### PR TITLE
IAP を導入する

### DIFF
--- a/operator.tf
+++ b/operator.tf
@@ -1,0 +1,22 @@
+resource "google_compute_firewall" "iap" {
+  name    = "iap-firewall"
+  network = google_compute_network.minecraft.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  /* > all IP addresses that IAP uses for TCP forwarding
+     > https://cloud.google.com/iap/docs/using-tcp-forwarding */
+  source_ranges = ["35.235.240.0/20"]
+  target_tags   = ["minecraft"]
+}
+
+resource "google_compute_instance_iam_member" "starter_instanceStandardUser" {
+  project = local.project
+  zone    = local.zone
+  /* 具体的なリソースに紐付けられている IAM policy であることに注意
+     google_compute_instance.name を渡すと、同名のまま作り直されたときに効果を失うことになる */
+  instance_name = google_compute_instance.minecraft.instance_id
+  role          = "roles/compute.osLogin"
+  member        = "group:${local.minecraft_starter_gqp}"
+}

--- a/services.tf
+++ b/services.tf
@@ -18,3 +18,7 @@ resource "google_project_service" "compute" {
   disable_dependent_services = true
 }
 
+resource "google_project_service" "iap" {
+  service                    = "iap.googleapis.com"
+  disable_dependent_services = true
+}


### PR DESCRIPTION
Fixes #12 

IAP 経由で ssh するにはファイアウォールの設定と IAM の設定をするのみだったので行なった。少なくとも Owner (なかひこくん) は接続できるようになる
https://cloud.google.com/compute/docs/oslogin/set-up-oslogin

注意点
---
- 組織外のユーザーが osLogin の操作をするには別のロールが必要だが No organization の場合はどうなるのかわからない
- とりあえず起動係に権限はつけてみているが、もう鯖缶ではというのはあり