### PR TITLE
GitHub Actions の導入

### DIFF
--- a/.github/calculate-archive-name.sh
+++ b/.github/calculate-archive-name.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eu
+set -o pipefail
+buf="$(mktemp)"
+find ./gcf-minecraft-starter -type f | sort | xargs sha256sum | md5sum | awk '{ print $1 }' > $buf
+echo "gcf-minecraft-starter_$(cat $buf).zip"

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,42 @@
+name: archive
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # 実装を見ると空でデフォルト値を参照できることがわかる
+          # https://github.com/actions/checkout/blob/2541b1294d2704b0964813337f33b291d3f8596b/src/input-helper.ts#L59-L76
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v3
+      - name: Calculate hash of gcf-minecraft-starter
+        run: |
+          echo -n "TARGET_ARCHIVE_NAME=" >> $GITHUB_ENV
+          ./.github/calculate-archive-name.sh >> $GITHUB_ENV
+      - name: Lookup build cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.TARGET_ARCHIVE_NAME }}
+          key: v1-gcf-archive-${{ env.TARGET_ARCHIVE_NAME }}
+          restore-keys: |
+            v1-gcf-archive-${{ env.TARGET_ARCHIVE_NAME }}
+      - name: Build and archive
+        run: |
+          if [ ! -e $TARGET_ARCHIVE_NAME ]; then
+            yarn --cwd gcf-minecraft-starter
+            make archive
+            mv gcf-minecraft-starter/dist/gcf-minecraft-starter.zip $TARGET_ARCHIVE_NAME
+          fi
+      - uses: actions/upload-artifact@v3
+        with:
+          name: gcf-archive
+          path: ${{ env.TARGET_ARCHIVE_NAME }}

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -3,7 +3,6 @@ on:
   workflow_call:
     inputs:
       ref:
-        required: false
         type: string
 permissions:
   contents: read

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -7,7 +7,6 @@ on:
         type: string
 permissions:
   contents: read
-  id-token: write
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,74 @@
+on:
+  workflow_call:
+    inputs:
+      command:
+        required: true
+        type: string
+      ref:
+        type: string
+      tfcmt:
+        type: boolean
+    secrets:
+      GCLOUD_PROJECT:
+        required: true
+      GCLOUD_PROJECT_ID:
+        required: true
+      DISCORD_API_KEY:
+        required: true
+      DISCORD_PUBLIC_KEY:
+        required: true
+      DISCORD_APPLICATION_ID:
+        required: true
+
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # 実装を見ると空でデフォルト値を参照できることがわかる
+          # https://github.com/actions/checkout/blob/2541b1294d2704b0964813337f33b291d3f8596b/src/input-helper.ts#L59-L76
+          ref: ${{ inputs.ref }}
+      - uses: hashicorp/setup-terraform@v2
+      - name: Setup github-comment & tfcmt
+        run: |
+          cd $(mktemp -d)
+          wget https://github.com/suzuki-shunsuke/tfcmt/releases/download/v3.2.2-0/tfcmt_linux_amd64.tar.gz
+          tar -vxf tfcmt_linux_amd64.tar.gz tfcmt
+          wget https://github.com/suzuki-shunsuke/github-comment/releases/download/v4.1.1/github-comment_4.1.1_linux_amd64.tar.gz
+          tar -vxf ./github-comment_4.1.1_linux_amd64.tar.gz github-comment
+          sudo mv tfcmt github-comment /usr/bin
+      - name: Calculate hash of gcf-minecraft-starter
+        run: |
+          echo -n "TF_VAR_gcf_minecraft_starter_zip_filepath=" >> $GITHUB_ENV
+          ./.github/calculate-archive-name.sh >> $GITHUB_ENV
+      - uses: actions/download-artifact@v3
+        with:
+          name: gcf-archive
+      - name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v0.7.1"
+        with:
+          workload_identity_provider: "projects/${{ secrets.GCLOUD_PROJECT_ID }}/locations/global/workloadIdentityPools/cicd/providers/github-actions"
+          service_account: "github-actions-${{ inputs.command }}@${{ secrets.GCLOUD_PROJECT }}.iam.gserviceaccount.com"
+          export_environment_variables: true
+      - name: terraform init
+        run: terraform init -input=false
+      - name: terraform ${{ inputs.command }}
+        run: |
+          args=""
+          if [ "${{ inputs.command }}" == "apply" ]; then
+            args="-auto-approve"
+          fi
+          if [ "${{ inputs.tfcmt }}" == "true" ]; then
+            github-comment hide
+            tfcmt ${{ inputs.command }} -- terraform ${{ inputs.command }} -input=false $args
+          else
+            terraform ${{ inputs.command }} -input=false $args
+          fi
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TF_VAR_discord_apikey: ${{ secrets.DISCORD_API_KEY }}
+          TF_VAR_discord_public_key: ${{ secrets.DISCORD_PUBLIC_KEY }}
+          TF_VAR_discord_application_id: ${{ secrets.DISCORD_APPLICATION_ID }}
+          TF_VAR_github_repository: ${{ github.repository }}

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -1,0 +1,21 @@
+name: terraform apply
+on:
+  push:
+    branches: ["main"]
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  archive:
+    uses: ./.github/workflows/archive.yml
+  apply:
+    needs: archive
+    uses: ./.github/workflows/terraform.yml
+    with:
+      command: apply
+    secrets:
+      GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
+      GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+      DISCORD_API_KEY: ${{ secrets.DISCORD_API_KEY }}
+      DISCORD_PUBLIC_KEY: ${{ secrets.DISCORD_PUBLIC_KEY }}
+      DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}

--- a/.github/workflows/terraform_plan_pull_request.yml
+++ b/.github/workflows/terraform_plan_pull_request.yml
@@ -8,12 +8,12 @@ permissions:
   pull-requests: write
 jobs:
   archive:
+    # リポジトリ内ならいつでも走らせる
+    # フォークでは context が異なり動かない。pull_request_target で代用する
+    if: github.event.pull_request.head.repo.id == github.event.pull_request.base.repo.id
     uses: ./.github/workflows/archive.yml
   plan:
     needs: archive
-    # リポジトリ内ならいつでも走らせる
-    # フォークでは context が異なり動かない。pull_request_target で代用する
-    if: ${{ github.event.head.repo.id == github.event.base.repo.id }}
     uses: ./.github/workflows/terraform.yml
     with:
       command: plan

--- a/.github/workflows/terraform_plan_pull_request.yml
+++ b/.github/workflows/terraform_plan_pull_request.yml
@@ -1,0 +1,26 @@
+name: terraform plan
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+jobs:
+  archive:
+    uses: ./.github/workflows/archive.yml
+  plan:
+    needs: archive
+    # リポジトリ内ならいつでも走らせる
+    # フォークでは context が異なり動かない。pull_request_target で代用する
+    if: ${{ github.event.head.repo.id == github.event.base.repo.id }}
+    uses: ./.github/workflows/terraform.yml
+    with:
+      command: plan
+      tfcmt: true
+    secrets:
+      GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
+      GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+      DISCORD_API_KEY: ${{ secrets.DISCORD_API_KEY }}
+      DISCORD_PUBLIC_KEY: ${{ secrets.DISCORD_PUBLIC_KEY }}
+      DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}

--- a/.github/workflows/terraform_plan_pull_request_target.yml
+++ b/.github/workflows/terraform_plan_pull_request_target.yml
@@ -1,0 +1,28 @@
+name: terraform plan
+on:
+  pull_request_target:
+    # fork でも origin の context で実行されるようにする
+    # 当然 unsafe であるので、権限を持つ人が review_request を行なったときに自動で走るという整理にする
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+    types: [review_requested]
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+jobs:
+  archive:
+    uses: ./.github/workflows/archive.yml
+  plan:
+    needs: archive
+    uses: ./.github/workflows/terraform.yml
+    with:
+      command: plan
+      ref: "refs/pull/${{ github.event.number }}/merge"
+      tfcmt: true
+    secrets:
+      GCLOUD_PROJECT: ${{ secrets.GCLOUD_PROJECT }}
+      GCLOUD_PROJECT_ID: ${{ secrets.GCLOUD_PROJECT_ID }}
+      DISCORD_API_KEY: ${{ secrets.DISCORD_API_KEY }}
+      DISCORD_PUBLIC_KEY: ${{ secrets.DISCORD_PUBLIC_KEY }}
+      DISCORD_APPLICATION_ID: ${{ secrets.DISCORD_APPLICATION_ID }}

--- a/.github/workflows/terraform_plan_pull_request_target.yml
+++ b/.github/workflows/terraform_plan_pull_request_target.yml
@@ -2,20 +2,35 @@ name: terraform plan
 on:
   pull_request_target:
     # fork でも origin の context で実行されるようにする
-    # 当然 unsafe であるので、権限を持つ人が review_request を行なったときに自動で走るという整理にする
+    # 当然 unsafe であるので、自動で走るのではなく write 権限が必要な操作を要求する整理にする
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-    types: [review_requested]
+    types: [labeled]
 
 permissions:
   contents: read
   id-token: write
   pull-requests: write
 jobs:
+  remove_label:
+    if: ${{ github.event.label.name == 'terraform plan' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'terraform plan'
+            })
   archive:
+    if: ${{ github.event.label.name == 'terraform plan' }}
     uses: ./.github/workflows/archive.yml
     with:
       ref: "refs/pull/${{ github.event.number }}/merge"
   plan:
+    if: ${{ github.event.label.name == 'terraform plan' }}
     needs: archive
     uses: ./.github/workflows/terraform.yml
     with:

--- a/.github/workflows/terraform_plan_pull_request_target.yml
+++ b/.github/workflows/terraform_plan_pull_request_target.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   archive:
     uses: ./.github/workflows/archive.yml
+    with:
+      ref: "refs/pull/${{ github.event.number }}/merge"
   plan:
     needs: archive
     uses: ./.github/workflows/terraform.yml

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,29 +2,28 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "4.19.0"
-  constraints = "4.19.0"
+  version     = "4.20.0"
+  constraints = "4.20.0"
   hashes = [
-    "h1:Qom1Evv0g66L2+oEiDzc3vgSKD2kUkpGcQt3R1m2Kdc=",
-    "h1:SDeCnrmQV6y01UaShD8tiRGXEm33EEZNPJXmRgyMedI=",
-    "zh:17aa6d222e00259bcf08a664a3a617ed1e41a6ab3428316be3b1aa997baa3642",
-    "zh:3e357ff59d6e75eef4b488db2a13105b7aa8a2bf71e27cb7fdcabfb30e6da5d7",
-    "zh:8af83e35bdda0df0f004c6294edc1d4119e457fab6eb7a73606529e245d8ae31",
-    "zh:9047896a8c7d3a9d749acdecaa7e5bc5589b2cbe54afeb30466a21597440d38f",
-    "zh:90dc3dbb28c368e76504f370c5f2d6887284369b072e4b74d0ad49eb87225ec8",
-    "zh:b3918565d747c92db62be37a91bdcd0a330334b25843746b85fe8279f7aa6c0b",
-    "zh:da845ee82ce4639bf348e9ac6e8f6a229c413a7e3d6a2e67a50c49561901d5ce",
-    "zh:db856e3830052ecc6b6ee5874bc9f7e97dcbbd9aaea6fc65e536121158cde630",
-    "zh:dc28a6f24a2aea6f7ddbfa4e69bc31796ceff88f0fefec99af2d1ee0f043af6c",
-    "zh:e5c05fee01c4c22077073155f0718c44e70983b865c6705e5e3d0f84df21fd8b",
-    "zh:fa7625309c9ed9df92657a3e398c827874415a885e52b13c4d6451265f5de485",
+    "h1:8gKms1E+nn/2Ukq4nVzH8PqSbDBAjQq4RMhqwBydZws=",
+    "zh:0ccae031531ee3d412681b93f2f6941e0e2c43c294d0ea7851a027aa99a32c8a",
+    "zh:1a84e894bf56aa4a7a663a198fd0576cf5a37407e65d2b46bf0c351eb626f7eb",
+    "zh:1c3708268482ad172b08adfc98aa11df5d4cd663d6be4b0ce4bb12c997c5bd49",
+    "zh:2075cb237b3eb90aaae669e4fe41507ce29ed4a4d349fa35f260995f9a73d393",
+    "zh:3ef464693ab8a743e230d0271006b942dc30090640c85efb1c6dfc807837c31f",
+    "zh:62d12548d136a96beded5300cd029e21bf7b89a063aa97422198309d4a7e4c55",
+    "zh:68eefedb6abd2da3fa068abcc9abd5798ff4cce73ff07cdb41a2ccd372e9cb52",
+    "zh:7d5d5e5e8d46a99423ba075064d875903189561fe0658e76c7b305d0c81a1e53",
+    "zh:80f9ccbf7307bc4343ae46defb3cbd572d92490013c16b02deccdb76a606c425",
+    "zh:a9664dc8e1f8a077bd6424afa62334e34fe250c425aa63fa22aaf1cf4a0f6499",
+    "zh:e14be25176dd3b1437107b010e6020f95f3da55be3b0d7c34245fe7a2c630e2e",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/google-beta" {
-  version = "4.20.0"
+  version     = "4.20.0"
+  constraints = "4.20.0"
   hashes = [
-    "h1:5X/EO0XrjeTXhdF20n2+I5lgz/qutG2rNMd0WmXm7IM=",
     "h1:qL8S+owt2j34uMg90T2Ip47PgPL2jT0bWjJbDxa2LB0=",
     "zh:4d14d5695bbc30564e042f689fbbd22f214e71a7f6cfc181c0c4a654123c008b",
     "zh:74f676b14d826d12022d0fb64c1051619dd4b7fcc7eb69a6a37f7e08cbcd8873",

--- a/actions.tf
+++ b/actions.tf
@@ -1,0 +1,91 @@
+resource "google_iam_workload_identity_pool" "cicd" {
+  provider                  = google-beta
+  workload_identity_pool_id = "cicd"
+  display_name              = "CI/CD pool"
+  description               = "identity pool for DevOps"
+}
+
+resource "google_iam_workload_identity_pool_provider" "github-actions" {
+  provider                           = google-beta
+  workload_identity_pool_id          = google_iam_workload_identity_pool.cicd.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github-actions"
+  description                        = "GitHub Actions identity pool"
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.aud"        = "assertion.aud"
+    "attribute.ref"        = "assertion.ref"
+    "attribute.event_name" = "assertion.event_name"
+  }
+  attribute_condition = "assertion.repository == \"${var.github_repository}\""
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_service_account" "github-actions-apply" {
+  account_id   = "github-actions-apply"
+  display_name = "GitHub Actions user for DevOps"
+}
+
+resource "google_service_account" "github-actions-plan" {
+  account_id   = "github-actions-plan"
+  display_name = "GitHub Actions user for DevOps"
+}
+
+resource "google_service_account_iam_binding" "github-actions-apply" {
+  service_account_id = google_service_account.github-actions-apply.name
+  role               = "roles/iam.workloadIdentityUser"
+  # 属性値による絞り込み https://cloud.google.com/iam/docs/workload-identity-federation#impersonation
+  members = [
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.cicd.name}/attribute.event_name/push"
+  ]
+}
+
+resource "google_service_account_iam_binding" "github-actions-plan" {
+  service_account_id = google_service_account.github-actions-plan.name
+  role               = "roles/iam.workloadIdentityUser"
+  # 属性値による絞り込み https://cloud.google.com/iam/docs/workload-identity-federation#impersonation
+  members = [
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.cicd.name}/*"
+  ]
+}
+
+resource "google_project_iam_member" "github-actions-apply" {
+  project = local.project
+  member  = "serviceAccount:${google_service_account.github-actions-apply.email}"
+  for_each = toset([
+    "roles/iam.securityAdmin",
+    "roles/iam.roleAdmin",
+    "roles/servicemanagement.quotaAdmin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.serviceAccountUser",
+    "roles/compute.admin",
+    "roles/cloudfunctions.admin",
+    "roles/storage.admin",
+    "roles/iap.admin",
+    "roles/iam.workloadIdentityPoolAdmin",
+    "roles/pubsub.admin",
+  ])
+  role = each.key
+}
+
+resource "google_project_iam_member" "github-actions-plan" {
+  project = local.project
+  member  = "serviceAccount:${google_service_account.github-actions-plan.email}"
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+  ])
+  role = each.key
+}
+
+resource "google_storage_bucket_iam_member" "github-actions" {
+  bucket = "${local.project}-terraform"
+  role   = "roles/storage.objectAdmin"
+  for_each = toset([
+    google_service_account.github-actions-plan.email,
+    google_service_account.github-actions-apply.email
+  ])
+  member = "serviceAccount:${each.key}"
+}

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.19.0"
+      version = "4.20.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "4.20.0"
     }
   }
 }
@@ -21,6 +25,11 @@ provider "google" {
   region  = local.region
 }
 
+provider "google-beta" {
+  project = local.project
+  region  = local.region
+}
+
 resource "google_compute_instance" "minecraft" {
   name                    = "minecraft-instance"
   machine_type            = "n1-standard-2"
@@ -28,7 +37,7 @@ resource "google_compute_instance" "minecraft" {
   tags                    = ["minecraft"]
   metadata_startup_script = "docker run -d --rm --name mcserver -p 42865:25565 -e EULA=TRUE -e VERSION=1.18.2 -e MEMORY=4G -e OPS=rinsuki,takanakahiko -v /var/minecraft:/data itzg/minecraft-server:latest;"
   metadata = {
-    enable-oslogin = "TRUE"
+    enable-oslogin  = "TRUE"
     shutdown-script = "docker exec mcserver rcon-cli stop"
   }
   boot_disk {

--- a/services_for_sa.tf
+++ b/services_for_sa.tf
@@ -1,0 +1,14 @@
+# Owner が操作するときにはなにもせずに使えるのに、Service Account から操作するときには service が有効でなければならないシリーズ
+# これらは有効である前提なので、別ファイルに分けている
+
+resource "google_project_service" "iam" {
+  service = "iam.googleapis.com"
+}
+
+resource "google_project_service" "iamcredentials" {
+  service = "iamcredentials.googleapis.com"
+}
+
+resource "google_project_service" "cloudresourcemanager" {
+  service = "cloudresourcemanager.googleapis.com"
+}

--- a/starter.tf
+++ b/starter.tf
@@ -13,9 +13,9 @@ resource "google_storage_bucket" "t98s-gcf-src" {
 }
 
 resource "google_storage_bucket_object" "gcf-minecraft-starter_zip" {
-  name   = "gcf-minecraft-starter_${filemd5("gcf-minecraft-starter/dist/gcf-minecraft-starter.zip")}.zip"
+  name   = basename(var.gcf_minecraft_starter_zip_filepath)
   bucket = google_storage_bucket.t98s-gcf-src.name
-  source = "gcf-minecraft-starter/dist/gcf-minecraft-starter.zip"
+  source = var.gcf_minecraft_starter_zip_filepath
 }
 
 resource "google_pubsub_topic" "gcf-minecraft-starter" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,8 @@ variable "discord_application_id" {
   type      = string
   sensitive = true
 }
+
+variable "github_repository" {
+  type    = string
+  default = "t98s/minecraft-server"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,7 @@ variable "github_repository" {
   type    = string
   default = "t98s/minecraft-server"
 }
+
+variable "gcf_minecraft_starter_zip_filepath" {
+  type = string
+}


### PR DESCRIPTION
Why
---
Closes #5

- GitHub の権限さえあればリソースの操作が可能となるようにしたい
- plan を誰でも確認できるようにし、PRを出すときに失敗しにくくしたい
- 手動でコマンドを使う手間を省き、イテレーションを高速にしたい

What
---
- 認証の仕組みとして Workload Identity + GitHub Actions OIDC Token の導入
- fork からの PR でも plan 結果が見られるように権限を工夫
    - `on: pull_request` では fork からの PR だと secrets や id-token: write が行えないが、これだと plan が行えない
    - `on: pull_request_target` では context が base repository になるので強い権限を与えられるようになる。しかしそのままでは secrets や id token → Google Cloud への強いアクセス権限が奪われるリスクがある
    - まず plan / apply 用の二種類に分け、apply 用の権限は Workload Identity の設定で `event_name` が `push` のときにしか参照できないようにした
    - また毎コミット行うのではなく、権限のあるユーザーの操作を挟んでから行うようにし、適当に Actions の yml を変更することで奪われるリスクを減らした
- リポジトリ内なら `on: pull_request` で常時 plan を行う

For @takanakahiko
---
- Secrets に次のものを投入する必要があります
    + `GCLOUD_PROJECT`: アルファベットのID = `t98s-minecraft-server`
    + `GCLOUD_PROJECT_ID`: 数値ID
    + `DISCORD_API_KEY`
    + `DISCORD_PUBLIC_KEY`
    + `DISCORD_APPLICATION_ID`
- 先に手動で apply を行ってから GitHub Actions を実行してみてください

📝 
---
- CI の Secrets はあとあと SecretManager に移行するといいかも