### PR TITLE
Stop using for_each with output values

### DIFF
--- a/actions.tf
+++ b/actions.tf
@@ -80,12 +80,14 @@ resource "google_project_iam_member" "github-actions-plan" {
   role = each.key
 }
 
-resource "google_storage_bucket_iam_member" "github-actions" {
+resource "google_storage_bucket_iam_member" "github-actions-plan" {
   bucket = "${local.project}-terraform"
   role   = "roles/storage.objectAdmin"
-  for_each = toset([
-    google_service_account.github-actions-plan.email,
-    google_service_account.github-actions-apply.email
-  ])
-  member = "serviceAccount:${each.key}"
+  member = google_service_account.github-actions-plan.email
+}
+
+resource "google_storage_bucket_iam_member" "github-actions-apply" {
+  bucket = "${local.project}-terraform"
+  role   = "roles/storage.objectAdmin"
+  member = google_service_account.github-actions-apply.email
 }


### PR DESCRIPTION
#15 が新規環境で apply できない問題を解消します。リソースを手動で作成しながらテストしていたのでできるものかと思っていました… 🙇🏼 

> the for_each value must be known before Terraform performs any remote resource actions
> https://www.terraform.io/language/meta-arguments/for_each#using-expressions-in-for_each