### PR TITLE
gcf-minecraft-starter のデプロイ周りの説明を消す

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # minecraft-server
 
 ## gcf-minecraft-starter
-- `make archive` してから terraform apply する
-- `make archive` は package.json が変更されたら zip を作り直す
-    * `version` を変更することを想定。`$ touch` してもよい
 - Discord アプリは適宜用意する
     * bot を有効にする
     * 権限設定は不要


### PR DESCRIPTION
GitHub Actions でやるため